### PR TITLE
need to install nvidia-docker2

### DIFF
--- a/nvidia-docker2-install.sh
+++ b/nvidia-docker2-install.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+curl -s -L https://nvidia.github.io/nvidia-docker/gpgkey | \
+  sudo apt-key add -
+distribution=$(. /etc/os-release;echo $ID$VERSION_ID)
+curl -s -L https://nvidia.github.io/nvidia-docker/$distribution/nvidia-docker.list | \
+  sudo tee /etc/apt/sources.list.d/nvidia-docker.list
+sudo apt-get update
+
+# Install nvidia-docker2 and reload the Docker daemon configuration
+sudo apt-get install -y nvidia-docker2
+sudo pkill -SIGHUP dockerd


### PR DESCRIPTION
以下のようなエラーはnvidia-docker2がインストールされていないので発生する
```
Creating nvidia-citadel-bionic ... error

ERROR: for nvidia-citadel-bionic  Cannot create container for service citadel-bionic-dev: Unknown runtime specified nvidia

ERROR: for citadel-bionic-dev  Cannot create container for service citadel-bionic-dev: Unknown runtime specified nvidia
ERROR: Encountered errors while bringing up the project.
```